### PR TITLE
Chatlist messages and auto scroll with new message

### DIFF
--- a/src/components/Chatinput.js
+++ b/src/components/Chatinput.js
@@ -12,8 +12,7 @@ function Chatinput({ chat, setChat }) {
 
     function handleSubmitText(event) {
         event.preventDefault()
-        setChat([...chat,{ id: chat.length + 1, text: text }])
-        //focus on newest messsage
+        setChat([...chat,{ id: chat.length + 1, text: text.trim() }])
         setText('')
     }
 

--- a/src/components/Chatlist.js
+++ b/src/components/Chatlist.js
@@ -40,9 +40,8 @@ const MessageArea = styled.ul`
 const Message = styled.li`
     margin: 0;
     border-radius: 5px;
-    color: white;
-    white-space: pre-line;
-    display: inline-block;
+    display: flex;
+    justify-content: flex-end;
 `
 
 const MessageText = styled.p`

--- a/src/components/Chatlist.js
+++ b/src/components/Chatlist.js
@@ -6,8 +6,6 @@ function Chatlist({ chat }) {
 
     const messages = useRef([])
 
-    console.log(messages)
-
     function focusNewMessage() {
         messages.current[messages.current.length - 1].scrollIntoView(false)
     }

--- a/src/components/Chatlist.js
+++ b/src/components/Chatlist.js
@@ -1,11 +1,22 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import styled from 'styled-components/macro'
 
 function Chatlist({chat}) {
+
+    useEffect(() => focusNewMessage(),[chat])
+
+    const messages = useRef([])
+
+    console.log(messages)
+
+    function focusNewMessage() {
+        messages.current[messages.current.length - 1].scrollIntoView(false)
+    }
+    
     return (
         <MessageArea>
-            {chat.map((message) => 
-            <Message key={message.id}>
+            {chat.map((message, index) => 
+            <Message ref={(element) => messages.current[index] = element} key={message.id}>
                 {message.text}
             </Message>)}
         </MessageArea>
@@ -19,7 +30,7 @@ flex-wrap: nowrap;
 grid-gap: 5px;
 margin-bottom: 60px;
 overflow-y: scroll;
-margin: 10px;
+padding: 10px;
 `
 
 const Message = styled.p`

--- a/src/components/Chatlist.js
+++ b/src/components/Chatlist.js
@@ -1,9 +1,8 @@
 import React, { useEffect, useRef } from 'react'
 import styled from 'styled-components/macro'
 
-function Chatlist({chat}) {
-
-    useEffect(() => focusNewMessage(),[chat])
+function Chatlist({ chat }) {
+    useEffect(() => focusNewMessage(), [chat])
 
     const messages = useRef([])
 
@@ -12,34 +11,49 @@ function Chatlist({chat}) {
     function focusNewMessage() {
         messages.current[messages.current.length - 1].scrollIntoView(false)
     }
-    
+
     return (
         <MessageArea>
-            {chat.map((message, index) => 
-            <Message ref={(element) => messages.current[index] = element} key={message.id}>
-                {message.text}
-            </Message>)}
+            {chat.map((message, index) => (
+                <Message
+                    ref={(element) => (messages.current[index] = element)}
+                    key={message.id}
+                >
+                    <MessageText>{message.text}</MessageText>
+                </Message>
+            ))}
         </MessageArea>
     )
 }
 
-const MessageArea = styled.section`
-display: flex;
-flex-direction: column;
-flex-wrap: nowrap;
-grid-gap: 5px;
-margin-bottom: 60px;
-overflow-y: scroll;
-padding: 10px;
+const MessageArea = styled.ul`
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    grid-template-columns: 1;
+    grid-gap: 5px;
+    margin: 0 0 60px 0;
+    overflow-y: scroll;
+    padding: 10px;
 `
 
-const Message = styled.p`
-margin: 0;
-border-radius: 5px;
-padding: 10px;
-background: #519e1e;
-color: white;
-white-space: pre-wrap;
+const Message = styled.li`
+    margin: 0;
+    border-radius: 5px;
+    color: white;
+    white-space: pre-line;
+    display: inline-block;
 `
+
+const MessageText = styled.p`
+    margin: 0;
+    border-radius: 5px;
+    padding: 10px;
+    background: #519e1e;
+    color: white;
+    white-space: pre-line;
+    display: inline-block;
+`
+
 
 export default Chatlist

--- a/src/pages/Tab1.js
+++ b/src/pages/Tab1.js
@@ -8,7 +8,6 @@ function Tab1() {
     const [chat, setChat] = useState([
         { id: 1, text: 'Schreibe etwas um den Chat zu beginnen' },
     ])
-    console.log(chat)
 
     return (
         <IonPageModified>


### PR DESCRIPTION
Changes:

- Messages are oriented to the right viewport side
- Messages are just as big as the content
- New Messages displayed under old ones
- With submit of a new message chatlist scrolls to new message 
- No unnecessary white space in messages


![Screen Shot 2021-01-17 at 13 03 30](https://user-images.githubusercontent.com/68147963/104839911-987b8c00-58c4-11eb-91cf-7bb2da6e6d00.png)



